### PR TITLE
Add ss58

### DIFF
--- a/template.json
+++ b/template.json
@@ -13,6 +13,7 @@
   "protocolId": "ksma",
   "consensusEngine": null,
   "properties": {
+    "ss58Format": 2,
     "tokenDecimals": 12,
     "tokenSymbol": "KSM"
   },


### PR DESCRIPTION
Adds the ss58 prefix. We might need to start parsing the addresses in the chain spec file to Kusama encoding now... paritytech/polkadot#393